### PR TITLE
report.py docs and some fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     start()
 ```
 
-Only functions marked with @test decorator will be marked as tests to execute. 
+Only functions wrapped with the @test decorator will be marked as tests to execute. 
 You can name your tests however you like, just put that @test decorator.
 
 ### Basic Asserts ###

--- a/checking/helpers/index_real.html
+++ b/checking/helpers/index_real.html
@@ -45,19 +45,19 @@
         <td>#total_tests</td>
     </tr>
     <tr>
-        <td><b style="color: #2e7d32">success tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #2e7d32">succeeded:</b></td>
         <td><span style="color: #2e7d32">#success_tests</span></td>
     </tr>
     <tr>
-        <td><b style="color: #d50000">failed tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #d50000">failed:</b></td>
         <td><span style="color: #d50000">#failed_tests</span></td>
     </tr>
     <tr>
-        <td><b style="color: #ff6f00">broken tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #ff6f00">broken:</b></td>
         <td><span style="color: #ff6f00">#broken_tests</span></td>
     </tr>
     <tr>
-        <td><b style="color: #757575">ignored tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #757575">ignored:</b></td>
         <td><span style="color: #757575">#ignored_tests</span></td>
     </tr>
     <td>

--- a/checking/helpers/index_real.html
+++ b/checking/helpers/index_real.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>Test Results for #suite_name</title>
-    <link rel="stylesheet" href="materialize.css">
-    <link rel="stylesheet" href="roboto.css">
+    <link rel="stylesheet" href="css/materialize.css">
+    <link rel="stylesheet" href="css/roboto.css">
     <script>
         function opclose(locator) {
             return function () {

--- a/checking/helpers/index_real.html
+++ b/checking/helpers/index_real.html
@@ -69,6 +69,3 @@
 
 <div style="width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;">
     <h2>Statistics:</h2>
-</div>
-</body>
-</html>

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -142,7 +142,7 @@ def _generate_html(test_suite: TestSuite) -> List[str]:
         html_lines.append(
             f"<h4 id='id_g_{count}' style='cursor: pointer;'>Group '{group}' (elapsed {group_time:.2} seconds), "
             f"success tests {succ}/{len(results)}:\n"
-            f"\t<script>document.querySelector('#id_g_{count}')."
+            f"    <script>document.querySelector('#id_g_{count}')."
             f"addEventListener('click', opclose_sibling('#id_g_{count}'))</script>\n</h4>\n"
             f"<ol style='display: none;'>\n")
         for test in results:

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -132,7 +132,7 @@ def _generate_html(test_suite: TestSuite) -> List[str]:
     html_lines = [base, ]
     if test_suite.is_empty():
         html_lines.append("<div id='empty'>Suite is empty! There are no tests!</div>\n")
-        html_lines.append('</body>\n</html>')
+        html_lines.append('\n</div>\n</body>\n</html>')
         return html_lines
     count = 1
     for group in test_suite.groups:
@@ -150,7 +150,7 @@ def _generate_html(test_suite: TestSuite) -> List[str]:
             count += 1
         html_lines.append('</ol>\n')
     _add_all_listeners(html_lines, count)
-    html_lines.append('\n</body>\n</html>')
+    html_lines.append('\n</div>\n</body>\n</html>')
     return html_lines
 
 

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -11,11 +11,15 @@ from checking.classes.basic_test import Test
 from checking.classes.basic_suite import TestSuite
 from checking.helpers.exception_traceback import get_trace_filtered_by_filename as filtered
 
+__all__ = [
+    'generate',
+]
+
 # Name for folder with results
 FOLDER = 'test_results'
 
 
-def add_text(name: str, value: str):
+def _add_text(name: str, value: str):
     """
     Add some text to test in report
     :param name: name of the parameter
@@ -25,7 +29,7 @@ def add_text(name: str, value: str):
     _add_to_test(name, value)
 
 
-def add_img(name: str, bytes_: bytes):
+def _add_img(name: str, bytes_: bytes):
     """
     Add some picture(screenshot) to test in report
     :param name: name of parameter

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -21,9 +21,10 @@ FOLDER = 'test_results'
 
 def _add_text(name: str, value: str):
     """
-    Add some text to test in report
-    :param name: name of the parameter
-    :param value: value of the parameter
+    Convenience wrapper for **_add_to_test()**, handles textual data.
+
+    :param name: text parameter name
+    :param value: text parameter value
     :return: None
     """
     _add_to_test(name, value)
@@ -31,9 +32,10 @@ def _add_text(name: str, value: str):
 
 def _add_img(name: str, bytes_: bytes):
     """
-    Add some picture(screenshot) to test in report
-    :param name: name of parameter
-    :param bytes_: bytes of picture (will be saved as png)
+    Convenience wrapper for **_add_to_test()**, handles binary (image) data.
+
+    :param name: image parameter name
+    :param bytes_: image parameter data
     :return: None
     """
     _add_to_test(name, bytes_)
@@ -41,9 +43,12 @@ def _add_img(name: str, bytes_: bytes):
 
 def _add_to_test(name: str, value: Union[bytes, str]):
     """
-    Looks for 5 frames deep in call stack to find current test and put data there
-    :param name: name of parameter to add
-    :param value: value of str or bytes
+    Helper, locates the current test instance by searching the last five stack frames,
+    then adds the specified report parameter data to the located test instance.
+    Data is added via the **Test** class **report_params** property.
+
+    :param name: parameter name
+    :param value: parameter data
     :return: None
     """
     try:
@@ -64,8 +69,9 @@ def _add_to_test(name: str, value: Union[bytes, str]):
 
 def generate(test_suite: TestSuite):
     """
-    The only public method to generate html report with all test results
-    :param test_suite: suite to save results to report
+    Generates an HTML report containing the test suite execution results.
+
+    :param test_suite: TestSuite instance to build the report for
     :return: None
     """
     path_to_template = is_file_exists.__globals__['__spec__'].origin
@@ -90,10 +96,11 @@ def generate(test_suite: TestSuite):
 
 def _create_info(html: str, suite: TestSuite) -> str:
     """
-    Generates Info section (header) of the report.
-    :param html: sting of the html report
-    :param suite: suite to get results from
-    :return: None
+    Helper, generates the report header (info section).
+
+    :param html: html report string
+    :param suite: TestSuite instance to generate the report for
+    :return: HTML string with the added report header
     """
     per_col = '#2e7d32'
     percent = len(suite.success()) / (suite.tests_count() / 100) if suite.tests_count() else 0.0
@@ -117,9 +124,10 @@ def _create_info(html: str, suite: TestSuite) -> str:
 
 def _generate_html(test_suite: TestSuite) -> List[str]:
     """
-    Generates html in list of strings
-    :param test_suite: suite to get all results from
-    :return: list of strings (html code)
+    Helper, generates HTML strings for each test group in a suite.
+
+    :param test_suite: TestSuite instance to generate the report for
+    :return: list of HTML strings, each containing the test results for a test group
     """
     with open(f'{FOLDER}{sep}index.html') as template:
         base = ''.join(template.readlines())
@@ -150,11 +158,24 @@ def _generate_html(test_suite: TestSuite) -> List[str]:
 
 
 def _write_file(lines: List[str]):
+    """
+    Helper, writes a list of strings to report's index.html file.
+
+    :param lines: list of prepared report HTML strings
+    :return:
+    """
     with open(f'{FOLDER}{sep}index.html', 'wt') as file:
         file.write(''.join(lines))
 
 
 def _add_all_listeners(lines: List[str], count: int):
+    """
+    Helper, adds JavaScript event listeners to the report.
+
+    :param lines: list of report HTML strings
+    :param count: number of sections to add listeners to
+    :return:
+    """
     a_l = [f"document.querySelector('#id_{_}').addEventListener('click',opclose('#id_{_}'));" for _ in range(1, count)]
     joined = '\n'.join(a_l)
     lines.append(f"<script>{joined}</script>")
@@ -162,10 +183,11 @@ def _add_all_listeners(lines: List[str], count: int):
 
 def _add_test_info(test: Test, lines: List[str], count: int):
     """
-    Add info about specific test
-    :param test: test to ger info from
-    :param lines: list of strings og html file
-    :param count: id for html tag
+    Helper, adds info header for a specific test.
+
+    :param test: Test instance to generate info for
+    :param lines: list of report HTML strings
+    :param count: test case id number to use in the HTML tag
     :return: None
     """
     time_ = 0.0 if test.duration() < 0.01 else test.duration()
@@ -196,10 +218,11 @@ def _add_test_info(test: Test, lines: List[str], count: int):
 
 def _get_rep_params(test: Test, count: int) -> str:
     """
-    Add info attached to test (text ot image)
-    :param test: test to get info from
-    :param count: id for element
-    :return: None
+    Helper, adds additional data (text or image to the test's HTML string.
+
+    :param test: Test instance to generate info for
+    :param count: test case id number to use in the HTML tags and image file names.
+    :return: test case additional info HTML string
     """
     rep_params = ''
     if not test.report_params:

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -1,12 +1,9 @@
-from os import sep
-from os import chdir
-from os import mkdir
-from os import path
+from os import sep, chdir, mkdir, path
 from sys import _getframe
 from datetime import datetime
 from typing import List, Union
-from checking.helpers.others import is_file_exists
 
+from checking.helpers.others import is_file_exists
 from checking.classes.basic_test import Test
 from checking.classes.basic_suite import TestSuite
 from checking.helpers.exception_traceback import get_trace_filtered_by_filename as filtered

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -8,7 +8,13 @@ from checking.classes.basic_test import Test
 from checking.classes.basic_suite import TestSuite
 from checking.helpers.exception_traceback import get_trace_filtered_by_filename as filtered
 
-# Name for folder with results
+__all__ = [
+    'generate',
+    'add_text',
+    'add_img'
+]
+
+# HTML report output folder
 FOLDER = 'test_results'
 
 

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -131,7 +131,7 @@ def _generate_html(test_suite: TestSuite) -> List[str]:
     base = _create_info(base, test_suite)
     html_lines = [base, ]
     if test_suite.is_empty():
-        html_lines.append("<div id='empty'>Suite is empty! There are no tests!</div>\n")
+        html_lines.append("<div id='empty'>No tests found in the suite!</div>\n")
         html_lines.append('\n</div>\n</body>\n</html>')
         return html_lines
     count = 1
@@ -141,7 +141,7 @@ def _generate_html(test_suite: TestSuite) -> List[str]:
         succ = len(test_suite.groups.get(group).tests_by_status('success'))
         html_lines.append(
             f"<h4 id='id_g_{count}' style='cursor: pointer;'>Group '{group}' (elapsed {group_time:.2} seconds), "
-            f"success tests {succ}/{len(results)}:\n"
+            f"succeeded tests {succ}/{len(results)}:\n"
             f"    <script>document.querySelector('#id_g_{count}')."
             f"addEventListener('click', opclose_sibling('#id_g_{count}'))</script>\n</h4>\n"
             f"<ol style='display: none;'>\n")
@@ -204,7 +204,7 @@ def _add_test_info(test: Test, lines: List[str], count: int):
         f"\t\t<div style='display: none;'>\n<table style='width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;'>\n<tbody>\n"
         f"\t\t\t<tr><td><b>Description:</b></td><td>'{test.description}'</td></tr>\n"
         f"\t\t\t<tr><td><b>Argument:</b></td><td> {test.argument}</td></tr>\n"
-        f"\t\t\t<tr><td><b>Attempt number:</b></td><td> {test.retries}</td></tr>\n"
+        f"\t\t\t<tr><td><b>Retries:</b></td><td> {test.retries}</td></tr>\n"
         f"\t\t\t<tr><td><b>Status:</b></td><td><b style='color:{st_col}'>{test.status.upper()}</b></td></tr>\n"
         f"\t\t\t<tr><td><b>Duration:</b></td><td> {time_:.3} seconds</td></tr>\n</tbody>\n</table>\n"
         f"{traceback}\n"

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -103,15 +103,15 @@ def _create_info(html: str, suite: TestSuite) -> str:
         per_col = '#d50000'
     start = datetime.fromtimestamp(suite.timer.start_time).strftime('%Y-%m-%d %H:%M:%S')
     end = datetime.fromtimestamp(suite.timer.end_time).strftime('%Y-%m-%d %H:%M:%S')
-    html = html.replace('#suite_name', suite.name). \
-        replace('#total_groups', str(len(suite.groups))). \
-        replace('#total_tests', str(suite.tests_count())). \
-        replace('#success_tests', str(len(suite.success()))). \
-        replace('#failed_tests', str(len(suite.failed()))). \
-        replace('#broken_tests', str(len(suite.broken()))). \
-        replace('#ignored_tests', str(len(suite.ignored()))). \
-        replace('#percent', f"<b style='color: {per_col}'>0.0 %</b>"). \
-        replace('#total_time', f"{suite.suite_duration():.2} seconds ({start} - {end})")
+    html = html.replace('#suite_name', suite.name) \
+        .replace('#total_groups', str(len(suite.groups))) \
+        .replace('#total_tests', str(suite.tests_count())) \
+        .replace('#success_tests', str(len(suite.success()))) \
+        .replace('#failed_tests', str(len(suite.failed()))) \
+        .replace('#broken_tests', str(len(suite.broken()))) \
+        .replace('#ignored_tests', str(len(suite.ignored()))) \
+        .replace('#percent', f"<b style='color: {per_col}'>0.0 %</b>") \
+        .replace('#total_time', f"{suite.suite_duration():.2} seconds ({start} - {end})")
     return html
 
 

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -84,7 +84,7 @@ def generate(test_suite: TestSuite):
     _write_file(html)
 
 
-def _create_info(html: str, suite: TestSuite):
+def _create_info(html: str, suite: TestSuite) -> str:
     """
     Generates Info section (header) of the report.
     :param html: sting of the html report
@@ -145,7 +145,7 @@ def _generate_html(test_suite: TestSuite) -> List[str]:
     return html_lines
 
 
-def _write_file(lines: list):
+def _write_file(lines: List[str]):
     with open(f'{FOLDER}{sep}index.html', 'wt') as file:
         file.write(''.join(lines))
 
@@ -190,7 +190,7 @@ def _add_test_info(test: Test, lines: List[str], count: int):
         f"\t\t</div>\n\t</li>\n")
 
 
-def _get_rep_params(test, count):
+def _get_rep_params(test: Test, count: int) -> str:
     """
     Add info attached to test (text ot image)
     :param test: test to get info from

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -107,15 +107,15 @@ def _create_info(html: str, suite: TestSuite) -> str:
         per_col = '#d50000'
     start = datetime.fromtimestamp(suite.timer.start_time).strftime('%Y-%m-%d %H:%M:%S')
     end = datetime.fromtimestamp(suite.timer.end_time).strftime('%Y-%m-%d %H:%M:%S')
-    html = html.replace('#suite_name', suite.name) \
-        .replace('#total_groups', str(len(suite.groups))) \
-        .replace('#total_tests', str(suite.tests_count())) \
-        .replace('#success_tests', str(len(suite.success()))) \
-        .replace('#failed_tests', str(len(suite.failed()))) \
-        .replace('#broken_tests', str(len(suite.broken()))) \
-        .replace('#ignored_tests', str(len(suite.ignored()))) \
-        .replace('#percent', f"<b style='color: {per_col}'>0.0 %</b>") \
-        .replace('#total_time', f"{suite.suite_duration():.2} seconds ({start} - {end})")
+    html = html.replace('#suite_name', suite.name). \
+        replace('#total_groups', str(len(suite.groups))). \
+        replace('#total_tests', str(suite.tests_count())). \
+        replace('#success_tests', str(len(suite.success()))). \
+        replace('#failed_tests', str(len(suite.failed()))). \
+        replace('#broken_tests', str(len(suite.broken()))). \
+        replace('#ignored_tests', str(len(suite.ignored()))). \
+        replace('#percent', f"<b style='color: {per_col}'>0.0 %</b>"). \
+        replace('#total_time', f"{suite.suite_duration():.2} seconds ({start} - {end})")
     return html
 
 

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -8,15 +8,11 @@ from checking.classes.basic_test import Test
 from checking.classes.basic_suite import TestSuite
 from checking.helpers.exception_traceback import get_trace_filtered_by_filename as filtered
 
-__all__ = [
-    'generate',
-]
-
-# HTML report output folder
+# Name for folder with results
 FOLDER = 'test_results'
 
 
-def _add_text(name: str, value: str):
+def add_text(name: str, value: str):
     """
     Convenience wrapper for **_add_to_test()**, handles textual data.
 
@@ -27,7 +23,7 @@ def _add_text(name: str, value: str):
     _add_to_test(name, value)
 
 
-def _add_img(name: str, bytes_: bytes):
+def add_img(name: str, bytes_: bytes):
     """
     Convenience wrapper for **_add_to_test()**, handles binary (image) data.
 

--- a/checking/helpers/report.py
+++ b/checking/helpers/report.py
@@ -15,7 +15,7 @@ __all__ = [
     'generate',
 ]
 
-# Name for folder with results
+# HTML report output folder
 FOLDER = 'test_results'
 
 
@@ -62,7 +62,7 @@ def _add_to_test(name: str, value: Union[bytes, str]):
                     current_test.report_params[str(name)] = str(value)
                 break
     except ValueError:
-        pass  # ignored, just deletes frame
+        pass    # ran out of stack frames, ignore the error and delete the frame reference
     finally:
         del frame
 

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -89,19 +89,19 @@ class TestReport(TestCase):
         <td>0</td>
     </tr>
     <tr>
-        <td><b style="color: #2e7d32">success tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #2e7d32">succeeded:</b></td>
         <td><span style="color: #2e7d32">0</span></td>
     </tr>
     <tr>
-        <td><b style="color: #d50000">failed tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #d50000">failed:</b></td>
         <td><span style="color: #d50000">0</span></td>
     </tr>
     <tr>
-        <td><b style="color: #ff6f00">broken tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #ff6f00">broken:</b></td>
         <td><span style="color: #ff6f00">0</span></td>
     </tr>
     <tr>
-        <td><b style="color: #757575">ignored tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #757575">ignored:</b></td>
         <td><span style="color: #757575">0</span></td>
     </tr>
     <td>
@@ -195,19 +195,19 @@ class TestReport(TestCase):
         <td>3</td>
     </tr>
     <tr>
-        <td><b style="color: #2e7d32">success tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #2e7d32">succeeded:</b></td>
         <td><span style="color: #2e7d32">0</span></td>
     </tr>
     <tr>
-        <td><b style="color: #d50000">failed tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #d50000">failed:</b></td>
         <td><span style="color: #d50000">0</span></td>
     </tr>
     <tr>
-        <td><b style="color: #ff6f00">broken tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #ff6f00">broken:</b></td>
         <td><span style="color: #ff6f00">0</span></td>
     </tr>
     <tr>
-        <td><b style="color: #757575">ignored tests:</b></td>
+        <td>&nbsp;&nbsp;&nbsp;<b style="color: #757575">ignored:</b></td>
         <td><span style="color: #757575">0</span></td>
     </tr>
     <td>

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -1,7 +1,12 @@
+import os
+import shutil
+
+from os.path import sep
 from unittest import main, TestCase
 
+from checking import test_break, TestBrokenException
 from checking.annotations import test
-from checking.helpers.report import _add_text, _add_img
+from checking.helpers.report import _add_text, _add_img, generate
 from checking.classes.basic_suite import TestSuite
 from tests.fixture_behaviour_test import clear
 
@@ -27,6 +32,201 @@ class TestReport(TestCase):
         t = list(TestSuite.get_instance().groups.values())[0].tests[0]
         t.run()
         self.assertEqual({b'B': 'A'}, t.report_params)
+
+    def test_generate_empty(self):
+        clear()
+        generate(TestSuite.get_instance())
+
+        with open(f'{os.getcwd()}{sep}test_results{sep}index.html') as f:
+            rep = ''.join([line for _, line in enumerate(f.readlines()) if _ != 64])
+
+        shutil.rmtree(f'{os.getcwd()}{sep}test_results')
+
+        self.assertEqual(rep, """<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Results for Default Test Suite</title>
+    <link rel="stylesheet" href="css/materialize.css">
+    <link rel="stylesheet" href="css/roboto.css">
+    <script>
+        function opclose(locator) {
+            return function () {
+                if (document.querySelector(locator).childNodes[3].style.display === 'none') {
+                    document.querySelector(locator).childNodes[3].style = 'display:block';
+                } else {
+                    document.querySelector(locator).childNodes[3].style = 'display:none';
+                }
+            }
+        }
+
+        function opclose_sibling(locator) {
+            return function () {
+                if (document.querySelector(locator).nextElementSibling.style.display === 'none') {
+                    document.querySelector(locator).nextElementSibling.style = 'display:block';
+                } else {
+                    document.querySelector(locator).nextElementSibling.style = 'display:none';
+                }
+            }
+        }
+    </script>
+</head>
+<body class="blue-grey lighten-5">
+<h1 style="text-align: center;" class="card-panel teal blue-grey darken-4 z-depth-3"><span
+        style="color: #eceff1; font-family: 'Roboto', sans-serif;">Info</span></h1>
+<table style="width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;">
+    <tbody>
+    <tr>
+        <td><b>Suite name:</b></td>
+        <td>Default Test Suite</td>
+    </tr>
+    <tr>
+        <td><b>Total groups:</b></td>
+        <td>0</td>
+    </tr>
+    <tr>
+        <td><b>Total tests:</b></td>
+        <td>0</td>
+    </tr>
+    <tr>
+        <td><b style="color: #2e7d32">success tests:</b></td>
+        <td><span style="color: #2e7d32">0</span></td>
+    </tr>
+    <tr>
+        <td><b style="color: #d50000">failed tests:</b></td>
+        <td><span style="color: #d50000">0</span></td>
+    </tr>
+    <tr>
+        <td><b style="color: #ff6f00">broken tests:</b></td>
+        <td><span style="color: #ff6f00">0</span></td>
+    </tr>
+    <tr>
+        <td><b style="color: #757575">ignored tests:</b></td>
+        <td><span style="color: #757575">0</span></td>
+    </tr>
+    <td>
+        <b>Success percent: </b><b style='color: #d50000'>0.0 %</b><br/>
+    </td>
+    </tbody>
+</table>
+
+<div style="width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;">
+    <h2>Statistics:</h2>
+<div id='empty'>Suite is empty! There are no tests!</div>
+
+</div>
+</body>
+</html>""")
+
+    def test_generate_normal(self):
+        def _1():
+            assert True is True, 'pass'
+
+        def _2():
+            assert True is False, 'fail'
+
+        def _3():
+            test_break()
+
+        clear()
+        test(_1)
+        test(_2)
+        test(_3)
+        suite = TestSuite.get_instance()
+        ts = list(suite.groups.values())[0].tests
+
+        ts[0].run()
+        with self.assertRaises(AssertionError):
+            ts[1].run()
+        with self.assertRaises(TestBrokenException):
+            ts[2].run()
+
+        generate(suite)
+
+        with open(f'{os.getcwd()}{sep}test_results{sep}index.html') as f:
+            rep = ''.join([line for _, line in enumerate(f.readlines()) if _ != 64])
+
+        shutil.rmtree(f'{os.getcwd()}{sep}test_results')
+
+        self.assertEqual(rep, """<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Test Results for Default Test Suite</title>
+    <link rel="stylesheet" href="css/materialize.css">
+    <link rel="stylesheet" href="css/roboto.css">
+    <script>
+        function opclose(locator) {
+            return function () {
+                if (document.querySelector(locator).childNodes[3].style.display === 'none') {
+                    document.querySelector(locator).childNodes[3].style = 'display:block';
+                } else {
+                    document.querySelector(locator).childNodes[3].style = 'display:none';
+                }
+            }
+        }
+
+        function opclose_sibling(locator) {
+            return function () {
+                if (document.querySelector(locator).nextElementSibling.style.display === 'none') {
+                    document.querySelector(locator).nextElementSibling.style = 'display:block';
+                } else {
+                    document.querySelector(locator).nextElementSibling.style = 'display:none';
+                }
+            }
+        }
+    </script>
+</head>
+<body class="blue-grey lighten-5">
+<h1 style="text-align: center;" class="card-panel teal blue-grey darken-4 z-depth-3"><span
+        style="color: #eceff1; font-family: 'Roboto', sans-serif;">Info</span></h1>
+<table style="width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;">
+    <tbody>
+    <tr>
+        <td><b>Suite name:</b></td>
+        <td>Default Test Suite</td>
+    </tr>
+    <tr>
+        <td><b>Total groups:</b></td>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td><b>Total tests:</b></td>
+        <td>3</td>
+    </tr>
+    <tr>
+        <td><b style="color: #2e7d32">success tests:</b></td>
+        <td><span style="color: #2e7d32">0</span></td>
+    </tr>
+    <tr>
+        <td><b style="color: #d50000">failed tests:</b></td>
+        <td><span style="color: #d50000">0</span></td>
+    </tr>
+    <tr>
+        <td><b style="color: #ff6f00">broken tests:</b></td>
+        <td><span style="color: #ff6f00">0</span></td>
+    </tr>
+    <tr>
+        <td><b style="color: #757575">ignored tests:</b></td>
+        <td><span style="color: #757575">0</span></td>
+    </tr>
+    <td>
+        <b>Success percent: </b><b style='color: #d50000'>0.0 %</b><br/>
+    </td>
+    </tbody>
+</table>
+
+<div style="width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;">
+    <h2>Statistics:</h2>
+<h4 id='id_g_1' style='cursor: pointer;'>Group 'report_test' (elapsed 0.0 seconds), success tests 0/0:
+    <script>document.querySelector('#id_g_1').addEventListener('click', opclose_sibling('#id_g_1'))</script>
+</h4>
+<ol style='display: none;'>
+</ol>
+<script></script>
+</div>
+</body>
+</html>""")
 
 
 if __name__ == '__main__':

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -6,7 +6,7 @@ from unittest import main, TestCase
 
 from checking import test_break, TestBrokenException
 from checking.annotations import test
-from checking.helpers.report import add_text, add_img
+from checking.helpers.report import add_text, add_img, generate
 from checking.classes.basic_suite import TestSuite
 from tests.fixture_behaviour_test import clear
 

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -1,7 +1,7 @@
 from unittest import main, TestCase
 
 from checking.annotations import test
-from checking.helpers.report import add_text, add_img
+from checking.helpers.report import _add_text, _add_img
 from checking.classes.basic_suite import TestSuite
 from tests.fixture_behaviour_test import clear
 
@@ -10,7 +10,7 @@ class TestReport(TestCase):
 
     def test_add_text(self):
         def _():
-            add_text("A", "B")
+            _add_text("A", "B")
 
         clear()
         test(_)
@@ -20,7 +20,7 @@ class TestReport(TestCase):
 
     def test_add_img(self):
         def _():
-            add_img("A", b"B")
+            _add_img("A", b"B")
 
         clear()
         test(_)

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -112,7 +112,7 @@ class TestReport(TestCase):
 
 <div style="width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;">
     <h2>Statistics:</h2>
-<div id='empty'>Suite is empty! There are no tests!</div>
+<div id='empty'>No tests found in the suite!</div>
 
 </div>
 </body>
@@ -218,7 +218,7 @@ class TestReport(TestCase):
 
 <div style="width: 80%; margin-left: auto; margin-right: auto; font-family: 'Roboto', sans-serif;">
     <h2>Statistics:</h2>
-<h4 id='id_g_1' style='cursor: pointer;'>Group 'report_test' (elapsed 0.0 seconds), success tests 0/0:
+<h4 id='id_g_1' style='cursor: pointer;'>Group 'report_test' (elapsed 0.0 seconds), succeeded tests 0/0:
     <script>document.querySelector('#id_g_1').addEventListener('click', opclose_sibling('#id_g_1'))</script>
 </h4>
 <ol style='display: none;'>

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -6,7 +6,7 @@ from unittest import main, TestCase
 
 from checking import test_break, TestBrokenException
 from checking.annotations import test
-from checking.helpers.report import _add_text, _add_img, generate
+from checking.helpers.report import add_text, add_img
 from checking.classes.basic_suite import TestSuite
 from tests.fixture_behaviour_test import clear
 
@@ -15,7 +15,7 @@ class TestReport(TestCase):
 
     def test_add_text(self):
         def _():
-            _add_text("A", "B")
+            add_text("A", "B")
 
         clear()
         test(_)
@@ -25,7 +25,7 @@ class TestReport(TestCase):
 
     def test_add_img(self):
         def _():
-            _add_img("A", b"B")
+            add_img("A", b"B")
 
         clear()
         test(_)


### PR DESCRIPTION
- update docstrings and comments
- add generate() tests for empty suite and a suite with some tests
- revert HTML edits which had broken the generated report markup
- fix HTML text phrasing